### PR TITLE
feat: totp command

### DIFF
--- a/action/totp.go
+++ b/action/totp.go
@@ -1,0 +1,68 @@
+package action
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"github.com/urfave/cli"
+)
+
+const (
+	totpPeriod = 30 // seconds
+)
+
+// TOTP implements time-based OTP token handling
+func (s *Action) TOTP(c *cli.Context) error {
+	name := c.Args().First()
+	if name == "" {
+		return errors.New("provide a password name")
+	}
+
+	content, err := s.Store.Get(name)
+	if err != nil {
+		return err
+	}
+
+	key, err := otp.NewKeyFromURL(string(content))
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	_, err = printCode(key.Secret(), now)
+	if err != nil {
+		return err
+	}
+
+	_, err = printCode(key.Secret(), now.Add(totpPeriod*time.Second))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func printCode(secret string, t time.Time) (int, error) {
+	code, err := totp.GenerateCodeCustom(strings.ToUpper(secret), t, totp.ValidateOpts{
+		Period:    totpPeriod,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	expiresAt := time.Unix(t.Unix()+totpPeriod-(t.Unix()%totpPeriod), 0)
+	secondsLeft := int(expiresAt.Sub(time.Now()) / time.Second)
+
+	if secondsLeft <= totpPeriod {
+		color.Yellow("%s lasts %ds \t|%s%s|", code, secondsLeft, strings.Repeat("=", totpPeriod-secondsLeft), strings.Repeat("-", secondsLeft))
+	} else {
+		color.Yellow("%s expires in %ds", code, secondsLeft)
+	}
+	return secondsLeft, nil
+}

--- a/main.go
+++ b/main.go
@@ -211,6 +211,14 @@ func main() {
 			},
 		},
 		{
+			Name:         "totp",
+			Usage:        "Generate time based token from stored secret",
+			Description:  "Tries to parse the saved string as a time-based one-time password secret and generate a token based on the current time",
+			Before:       action.Initialized,
+			Action:       action.TOTP,
+			BashComplete: action.Complete,
+		},
+		{
 			Name:        "git",
 			Usage:       "Do git things",
 			Description: "If the password store is a git repository, execute a git command specified by git-command-args.",


### PR DESCRIPTION
# Add `totp` command

This command is supposed to do the same like the [Google Authenticator App](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2).

To use it, save the time base token generator seed that should look like that `otpauth://totp/GitHub:<user>?secret=<secret>&issuer=GitHub` as a password in the password store, for example under `github.com/authenticator`. Then use it by calling `gopass totp github.com/authenticator`.

It will print out the following:
```
123456 lasts 28s 	|==----------------------------|
789123 expires in 58s
```

## Why this feature?

Of course, when you save it to the password store besides the password for an account, it is not true 2fa anymore. The only safe place besides saving it to the password store is having the secret exclusively in the Google Authenticator App. Currently there is no way to extract the secrets from the app as long as the phone is not rooted. In case you root your phone, you lose all your secrets. So you can say when keeping the secrets only in the Google Authenticator App they're pretty safe.

I had the same setup with 27 2fa tokens and then I got a new phone. There was no way of getting the secrets. I could use the old phone for getting a new seed and set it up on my new phone. But for every provider I had to click through another user interface for setting up 2fa again. Sometimes I had to wait for SMS.

And I don't want to know what would have happened if I just had lost my phone.

The real reason for me to have this feature is to not depend on having my phone. And not to get my phone everyday on work when I have to log into the AWS console, because this beautiful pile of CSS logs me out of my account every day.